### PR TITLE
Allow the use of $ for inline math

### DIFF
--- a/_plugins/figure.rb
+++ b/_plugins/figure.rb
@@ -28,7 +28,7 @@ module Jekyll
         unless @caption.nil?
           figure_caption = @caption.gsub!(/\A"|"\Z/, '')
           figure_caption = converter.convert(figure_caption).gsub(/<\/?p[^>]*>/, '').chomp
-          figure_caption = figure_caption.gsub!(/[$]([^$]*)[$]/, "{% latex %}\\1{% endlatex %}")
+          figure_caption = figure_caption.gsub!(/\\\(([^\\]*)\\\)/, "{% latex %}\\1{% endlatex %}")
           figure_caption = Liquid::Template.parse(figure_caption).render(context)
           figure_caption = "  <figcaption>#{figure_caption}</figcaption>\n"
         end

--- a/_plugins/use_dollar.rb
+++ b/_plugins/use_dollar.rb
@@ -1,0 +1,22 @@
+module Jekyll
+  class UseDollarGenerator < Generator
+    safe true
+
+    def generate(site)
+      site.pages.each do |page|
+        page.content = replace(page.content, page.ext)
+      end
+
+      site.posts.docs.each do |post|
+        post.content = replace(post.content, ".md")
+      end
+    end
+
+    def replace(content, ext)
+      if ext == ".md"
+        content.gsub!(/[$]([^$]*)[$]/, "{% latex %}\\1{% endlatex %}")
+      end
+      content
+    end
+  end
+end


### PR DESCRIPTION
A simple Jekyll hack that allows `$` to be used instead of `{% latex %} ... {% endlatex %}`

For captions a different syntax is needed, thus `\\( ... \\)` can be used there.
