### PR TITLE
Remove official from blog name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
-title: Official Blog of the Mir project
+title: The Mir Blog
 email: team@mir.rocks
 description: > # this means to ignore newlines until "baseurl:"
-  Official blog of the Mir project. Stay in touch with the lastest developments
+  The Mir Blog. Stay in touch with the lastest developments
   in scientific computing for D.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://blog.mir.dlang.io" # the base hostname & protocol for your site


### PR DESCRIPTION
@9il I think for now the term "official" is a bit too ambitious.

Other ideas for titles:
- The Mir Blog
- Scientific D Blog
  ...
